### PR TITLE
Add ChordPro lyrics support

### DIFF
--- a/lib/data/song/lyrics/format.dart
+++ b/lib/data/song/lyrics/format.dart
@@ -7,7 +7,11 @@ import 'package:drift/drift.dart';
 enum LyricsFormat {
   /// OpenSong format - uses brackets for sections, dots for chord lines.
   /// See: http://www.opensong.org/
-  opensong('opensong');
+  opensong('opensong'),
+
+  /// ChordPro format - uses inline bracket chords and brace directives.
+  /// See: https://www.chordpro.org/
+  chordpro('chordpro');
 
   final String value;
   const LyricsFormat(this.value);

--- a/lib/data/song/lyrics/parser.dart
+++ b/lib/data/song/lyrics/parser.dart
@@ -1,3 +1,4 @@
+import 'package:dart_chordpro/dart_chordpro.dart' as cp;
 import 'package:dart_opensong/dart_opensong.dart' as os;
 
 import 'format.dart';
@@ -19,6 +20,7 @@ sealed class LyricsParser {
   factory LyricsParser.forFormat(LyricsFormat format) {
     return switch (format) {
       LyricsFormat.opensong => const OpenSongParser(),
+      LyricsFormat.chordpro => const ChordProParser(),
     };
   }
 
@@ -28,17 +30,67 @@ sealed class LyricsParser {
   List<ParsedVerse> parse(String lyrics);
 
   /// Check if the lyrics content contains chord annotations.
-  bool hasChords(String lyrics);
+  bool hasChords(String lyrics) {
+    try {
+      return parse(lyrics).any(
+        (verse) => verse.parts.whereType<ParsedVerseLine>().any(
+          (line) => line.segments.any((segment) => segment.chord != null),
+        ),
+      );
+    } catch (_) {
+      return false;
+    }
+  }
 
   /// Extract the first line of actual lyrics (not section headers or chords).
   ///
   /// Used for displaying a preview/subtitle of the song.
-  String getFirstLine(String lyrics);
+  String getFirstLine(String lyrics) {
+    try {
+      final verses = parse(lyrics);
+      if (verses.isEmpty) {
+        return '';
+      }
+
+      for (final part in verses.first.parts.whereType<ParsedVerseLine>()) {
+        final line = part.lyrics.trim();
+        if (line.isNotEmpty) {
+          return line;
+        }
+      }
+
+      return '';
+    } catch (_) {
+      return '';
+    }
+  }
 
   /// Get plain text content without chords or section markers.
   ///
   /// Used for text-only display or export.
-  String getText(String lyrics);
+  String getText(String lyrics) {
+    try {
+      final verseTexts = parse(lyrics)
+          .map(
+            (verse) => verse.parts
+                .map(
+                  (part) => switch (part) {
+                    ParsedVerseLine(:final lyrics) => lyrics.trimRight(),
+                    ParsedEmptyLine() => '',
+                    _ => null,
+                  },
+                )
+                .whereType<String>()
+                .join('\n')
+                .trimRight(),
+          )
+          .where((text) => text.isNotEmpty)
+          .toList();
+      return verseTexts.join('\n\n');
+    } catch (_) {
+      return '';
+    }
+  }
 }
 
 /// OpenSong format parser using the dart_opensong package.
@@ -54,84 +106,133 @@ class OpenSongParser extends LyricsParser {
   @override
   List<ParsedVerse> parse(String lyrics) {
     final osVerses = os.getVersesFromString(lyrics);
-    return osVerses.map((v) => OpenSongVerse(v)).toList();
-  }
-
-  @override
-  bool hasChords(String lyrics) {
-    // OpenSong chord lines start with a dot after newline
-    return RegExp(r'\n\.').hasMatch(lyrics);
-  }
-
-  @override
-  String getFirstLine(String lyrics) {
-    try {
-      final verses = os.getVersesFromString(lyrics);
-      if (verses.isEmpty) return '';
-
-      final firstVerse = verses.first;
-      for (final part in firstVerse.parts) {
-        if (part case os.VerseLine(:final segments)) {
-          return segments
-              .map((segment) => segment.lyrics)
-              .join()
-              .trim();
-        }
-      }
-
-      return '';
-    } catch (_) {
-      return '';
-    }
-  }
-
-  @override
-  String getText(String lyrics) {
-    // TODO: Implement proper plain text extraction
-    // Should strip chords, section markers, and formatting
-    throw UnimplementedError('OpenSongParser.getText() not yet implemented');
+    return osVerses.map(_mapOpenSongVerse).toList(growable: false);
   }
 }
 
-/// Abstract representation of a parsed verse.
+/// ChordPro format parser using the dart_chordpro package.
 ///
-/// Different format parsers may return different concrete implementations,
-/// but the UI should work with this common interface.
-sealed class ParsedVerse {
-  const ParsedVerse();
+/// Supported ChordPro subset:
+/// - inline chords like `[C]Amazing [G]grace`
+/// - verse / chorus / bridge blocks
+/// - chorus recall
+/// - comment directives
+/// - page and column breaks
+class ChordProParser extends LyricsParser {
+  const ChordProParser();
 
-  /// The verse tag/type (e.g., "V1", "C", "B2")
-  String get tag;
-
-  /// The verse type identifier (e.g., "V" for verse, "C" for chorus)
-  String get type;
-
-  /// The verse index number (e.g., 1 for V1, 2 for V2)
-  int? get index;
-
-  /// The parsed content parts of this verse.
-  /// The concrete type depends on the format parser.
-  List<dynamic> get parts;
+  @override
+  List<ParsedVerse> parse(String lyrics) {
+    final cpVerses = cp.getVersesFromString(lyrics);
+    return cpVerses.map(_mapChordProVerse).toList(growable: false);
+  }
 }
 
-/// Verse implementation wrapping dart_opensong's Verse type.
-class OpenSongVerse extends ParsedVerse {
-  final os.Verse _verse;
+class ParsedVerse {
+  const ParsedVerse({
+    required this.type,
+    required this.index,
+    required this.parts,
+    this.label,
+  });
 
-  const OpenSongVerse(this._verse);
+  final String type;
+  final int? index;
+  final String? label;
+  final List<ParsedVersePart> parts;
 
-  @override
-  String get tag => _verse.tag;
-
-  @override
-  String get type => _verse.type;
-
-  @override
-  int? get index => _verse.index;
-
-  @override
-  List<os.VersePart> get parts => _verse.parts;
-
-  /// Access the underlying opensong verse for format-specific operations.
-  os.Verse get raw => _verse;
+  String get tag => label ?? '$type${index ?? ''}';
 }
+
+sealed class ParsedVersePart {
+  const ParsedVersePart();
+}
+
+class ParsedVerseLine extends ParsedVersePart {
+  const ParsedVerseLine(this.segments);
+
+  final List<ParsedVerseLineSegment> segments;
+
+  String get lyrics => segments.map((segment) => segment.lyrics).join();
+}
+
+class ParsedCommentLine extends ParsedVersePart {
+  const ParsedCommentLine(this.comment);
+
+  final String comment;
+}
+
+class ParsedNewSlide extends ParsedVersePart {
+  const ParsedNewSlide();
+}
+
+class ParsedEmptyLine extends ParsedVersePart {
+  const ParsedEmptyLine();
+}
+
+class ParsedUnsupportedLine extends ParsedVersePart {
+  const ParsedUnsupportedLine(this.original);
+
+  final String original;
+}
+
+class ParsedVerseLineSegment {
+  const ParsedVerseLineSegment(
+    this.chord,
+    this.lyrics, {
+    this.hyphenAfter = false,
+  });
+
+  final String? chord;
+  final String lyrics;
+  final bool hyphenAfter;
+}
+
+ParsedVerse _mapOpenSongVerse(os.Verse verse) => ParsedVerse(
+  type: verse.type,
+  index: verse.index,
+  parts: verse.parts.map(_mapOpenSongPart).toList(growable: false),
+);
+
+ParsedVersePart _mapOpenSongPart(os.VersePart part) => switch (part) {
+  os.VerseLine(:final segments) => ParsedVerseLine(
+    segments
+        .map(
+          (segment) => ParsedVerseLineSegment(
+            segment.chord,
+            segment.lyrics,
+            hyphenAfter: segment.hyphenAfter,
+          ),
+        )
+        .toList(growable: false),
+  ),
+  os.CommentLine(:final comment) => ParsedCommentLine(comment),
+  os.NewSlide() => const ParsedNewSlide(),
+  os.EmptyLine() => const ParsedEmptyLine(),
+  os.UnsupportedLine(:final original) => ParsedUnsupportedLine(original),
+};
+
+ParsedVerse _mapChordProVerse(cp.Verse verse) => ParsedVerse(
+  type: verse.type,
+  index: verse.index,
+  label: verse.label,
+  parts: verse.parts.map(_mapChordProPart).toList(growable: false),
+);
+
+ParsedVersePart _mapChordProPart(cp.VersePart part) => switch (part) {
+  cp.VerseLine(:final segments) => ParsedVerseLine(
+    segments
+        .map(
+          (segment) => ParsedVerseLineSegment(
+            segment.chord,
+            segment.lyrics,
+            hyphenAfter: segment.hyphenAfter,
+          ),
+        )
+        .toList(growable: false),
+  ),
+  cp.CommentLine(:final comment) => ParsedCommentLine(comment),
+  cp.NewSlide() => const ParsedNewSlide(),
+  cp.EmptyLine() => const ParsedEmptyLine(),
+  cp.UnsupportedLine(:final original) => ParsedUnsupportedLine(original),
+};

--- a/lib/services/song/verse_tag_pretty.dart
+++ b/lib/services/song/verse_tag_pretty.dart
@@ -1,4 +1,8 @@
-String getPrettyVerseTagFrom(String type, int? index) {
+String getPrettyVerseTagFrom(String type, int? index, {String? label}) {
+  if (label != null && label.trim().isNotEmpty) {
+    return label.trim();
+  }
+
   if (type.isEmpty) {
     if (index == null) {
       return '';

--- a/lib/ui/song/lyrics/view.dart
+++ b/lib/ui/song/lyrics/view.dart
@@ -1,5 +1,4 @@
 import 'package:chord_transposer/chord_transposer.dart';
-import 'package:dart_opensong/dart_opensong.dart' as os;
 import 'package:fading_edge_scrollview/fading_edge_scrollview.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -96,11 +95,7 @@ class LyricsView extends ConsumerWidget {
                   ...verses.map(
                     (verse) => SizedBox(
                       width: cardWidth,
-                      child: VerseCard(
-                        song,
-                        verse as OpenSongVerse,
-                        transpose: transpose,
-                      ),
+                      child: VerseCard(song, verse, transpose: transpose),
                     ),
                   ),
                 ],
@@ -116,7 +111,7 @@ class LyricsView extends ConsumerWidget {
 class VerseCard extends ConsumerStatefulWidget {
   const VerseCard(this.song, this.verse, {required this.transpose, super.key});
 
-  final OpenSongVerse verse;
+  final ParsedVerse verse;
   final Song song;
   final SongTranspose transpose;
 
@@ -163,6 +158,7 @@ class _VerseCardState extends ConsumerState<VerseCard> {
                       getPrettyVerseTagFrom(
                         widget.verse.type,
                         widget.verse.index,
+                        label: widget.verse.label,
                       ),
                       style: TextStyle(
                         color: Theme.of(context).colorScheme.onPrimary,
@@ -179,10 +175,10 @@ class _VerseCardState extends ConsumerState<VerseCard> {
                   ),
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
-                    children: widget.verse.raw.parts
+                    children: widget.verse.parts
                         .map(
-                          (versePart) => switch (versePart) {
-                            os.VerseLine(:final segments) => Wrap(
+                          (part) => switch (part) {
+                            ParsedVerseLine(:final segments) => Wrap(
                               alignment: WrapAlignment.start,
                               crossAxisAlignment: WrapCrossAlignment.start,
                               children: segments
@@ -196,18 +192,19 @@ class _VerseCardState extends ConsumerState<VerseCard> {
                                   )
                                   .toList(),
                             ),
-                            os.CommentLine(:final comment) => Text(
+                            ParsedCommentLine(:final comment) => Text(
                               comment,
                               style: TextStyle(fontStyle: FontStyle.italic),
                             ),
-                            os.NewSlide() => Divider(),
-                            os.EmptyLine() => Text(''),
-                            os.UnsupportedLine(:final original) => LErrorCard(
-                              type: LErrorType.info,
-                              title: 'Ismeretlen sortípus',
-                              message: original,
-                              icon: Icons.question_mark,
-                            ),
+                            ParsedNewSlide() => Divider(),
+                            ParsedEmptyLine() => Text(''),
+                            ParsedUnsupportedLine(:final original) =>
+                              LErrorCard(
+                                type: LErrorType.info,
+                                title: 'Ismeretlen sortípus',
+                                message: original,
+                                icon: Icons.question_mark,
+                              ),
                           },
                         )
                         .toList(),
@@ -231,8 +228,8 @@ class LyricsSegment extends ConsumerWidget {
     required this.segment,
   });
 
-  final List<os.VerseLineSegment> segments;
-  final os.VerseLineSegment segment;
+  final List<ParsedVerseLineSegment> segments;
+  final ParsedVerseLineSegment segment;
   final Song song;
   final SongTranspose transpose;
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -314,6 +314,15 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  dart_chordpro:
+    dependency: "direct main"
+    description:
+      path: "."
+      ref: a9cb4b5
+      resolved-ref: a9cb4b5247df18c4d90759c204270c8edc35517c
+      url: "https://github.com/reformatus/dart_chordpro"
+    source: git
+    version: "0.0.1"
   dart_opensong:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,10 @@ dependencies:
   msgpack_dart: ^1.0.1
   mailto: ^2.0.0
   flutter_markdown: ^0.7.7+1
+  dart_chordpro:
+    git:
+      url: https://github.com/reformatus/dart_chordpro
+      ref: a9cb4b5
   dart_opensong: ^0.0.4
   chord_transposer:
     git:

--- a/test/data/lyrics_parser_test.dart
+++ b/test/data/lyrics_parser_test.dart
@@ -41,4 +41,38 @@ void main() {
       expect(parser.getFirstLine(lyrics), isEmpty);
     });
   });
+
+  group('ChordProParser', () {
+    const parser = ChordProParser();
+
+    test('returns first lyric line from inline chord lyrics', () {
+      const lyrics = '''
+{title: Sample}
+{start_of_verse: 1}
+[C]Amazing [G]grace
+{end_of_verse}
+''';
+
+      expect(parser.getFirstLine(lyrics), equals('Amazing grace'));
+      expect(parser.hasChords(lyrics), isTrue);
+      expect(parser.getText(lyrics), equals('Amazing grace'));
+    });
+
+    test('parses chorus recall and labels', () {
+      final verses = parser.parse('''
+{soc: Refrain}
+[F]Halle[G]lujah
+{eoc}
+{chorus: Refrain}
+''');
+
+      expect(verses, hasLength(2));
+      expect((verses.first.type, verses.first.label), equals(('C', 'Refrain')));
+      expect((verses.last.type, verses.last.label), equals(('C', 'Refrain')));
+      expect(
+        (verses.last.parts.single as ParsedVerseLine).lyrics,
+        equals('Hallelujah'),
+      );
+    });
+  });
 }

--- a/test/data/song_from_bank_api_json_test.dart
+++ b/test/data/song_from_bank_api_json_test.dart
@@ -40,19 +40,22 @@ void main() {
       );
     });
 
-    test('keeps escaped lyrics unchanged when caller does not normalize first', () {
-      final song = Song.fromBankApiJson({
-        'uuid': 'song-4',
-        'title': 'Rock &amp; Roll',
-        'lyrics': '[V1]\n Tom &amp; Jerry',
-        'lyrics_format': 'opensong',
-        'composer': 'A &amp; B',
-      });
+    test(
+      'keeps escaped lyrics unchanged when caller does not normalize first',
+      () {
+        final song = Song.fromBankApiJson({
+          'uuid': 'song-4',
+          'title': 'Rock &amp; Roll',
+          'lyrics': '[V1]\n Tom &amp; Jerry',
+          'lyrics_format': 'opensong',
+          'composer': 'A &amp; B',
+        });
 
-      expect(song.title, equals('Rock &amp; Roll'));
-      expect(song.lyrics, equals('[V1]\n Tom &amp; Jerry'));
-      expect(song.contentMap['composer'], equals('A &amp; B'));
-    });
+        expect(song.title, equals('Rock &amp; Roll'));
+        expect(song.lyrics, equals('[V1]\n Tom &amp; Jerry'));
+        expect(song.contentMap['composer'], equals('A &amp; B'));
+      },
+    );
 
     test('stores decoded metadata in contentMap when input is normalized', () {
       final song = Song.fromBankApiJson({
@@ -67,6 +70,18 @@ void main() {
       expect(song.lyrics, equals('[V1]\n Tom & Jerry'));
       expect(song.lyricsFormat, equals(LyricsFormat.opensong));
       expect(song.contentMap['composer'], equals('A & B'));
+    });
+
+    test('uses the supplied ChordPro lyrics format', () {
+      final song = Song.fromBankApiJson({
+        'uuid': 'song-4',
+        'title': 'Song 4',
+        'lyrics': '[C]Amazing grace',
+        'lyricsFormat': 'chordpro',
+      });
+
+      expect(song.lyrics, equals('[C]Amazing grace'));
+      expect(song.lyricsFormat, equals(LyricsFormat.chordpro));
     });
   });
 }


### PR DESCRIPTION
## Summary
- add a new `dart_chordpro` parser package in the Reformatus org and consume it as a pinned git dependency
- extend the app lyrics parsing layer with format-agnostic verse, line, comment, and chord segment primitives
- add ChordPro support for inline chords, verse/chorus/bridge blocks, chorus recall, comments, and page breaks while keeping OpenSong rendering on the same UI path

## Companion repo
- https://github.com/reformatus/dart_chordpro

## Validation
- `dart analyze` in `dart_chordpro`
- `dart test` in `dart_chordpro`
- `flutter analyze lib/data/song/lyrics/format.dart lib/data/song/lyrics/parser.dart lib/services/song/verse_tag_pretty.dart lib/ui/song/lyrics/view.dart test/data/lyrics_parser_test.dart test/data/song_from_bank_api_json_test.dart`
- `flutter test test/data`

## Notes
- full-project `flutter analyze` still reports existing warnings in `lib/services/app_links/cue_compression.dart`, `lib/services/cue/compression.dart`, and `test/router/imperative_url_reflection_test.dart`; this PR does not add new analyzer issues
