### PR TITLE
Fix iOS Universal Links entitlements wiring

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -470,6 +470,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -652,6 +653,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
@@ -674,6 +676,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;


### PR DESCRIPTION
## Summary
- add `CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements` to the iOS Runner target Debug, Release, and Profile configs
- ensure the app binary is actually signed with the Associated Domains entitlement used for Universal Links

## Why
`Runner.entitlements` existed, but the Xcode project did not reference it in build settings. That means `lyric:` custom-scheme links could work while `https://.../launch/...` Universal Links failed on iOS.

## Validation
- confirmed the project previously had no `CODE_SIGN_ENTITLEMENTS` entries for the iOS Runner target
- confirmed the hosted `apple-app-site-association` file now matches `MYUTW2GF6J.org.lyricapp.sofar` on `app.sofarhangolo.hu`