### PR TITLE
Fix desktop deep-linking configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -413,7 +413,20 @@ jobs:
         if: ${{ steps.developer-id-ready.outputs.ready == 'true' }}
         run: |
           APP_PATH="$(find build/macos/Build/Products/Release -maxdepth 1 -name '*.app' -print -quit)"
-          codesign --deep --force --options runtime --sign "${{ secrets.MACOS_DEVELOPER_ID_APPLICATION }}" "$APP_PATH"
+          codesign \
+            --deep \
+            --force \
+            --options runtime \
+            --entitlements macos/Runner/DirectDistribution.entitlements \
+            --sign "${{ secrets.MACOS_DEVELOPER_ID_APPLICATION }}" \
+            "$APP_PATH"
+
+      - name: Verify macOS direct-distribution entitlements
+        if: ${{ steps.developer-id-ready.outputs.ready == 'true' }}
+        run: |
+          APP_PATH="$(find build/macos/Build/Products/Release -maxdepth 1 -name '*.app' -print -quit)"
+          codesign -d --entitlements :- "$APP_PATH" > "$RUNNER_TEMP/direct-distribution-entitlements.plist"
+          grep -q 'applinks:app.sofarhangolo.hu' "$RUNNER_TEMP/direct-distribution-entitlements.plist"
 
       - name: Build DMG
         run: |
@@ -508,6 +521,13 @@ jobs:
             -archivePath "$RUNNER_TEMP/Runner.xcarchive" \
             -exportOptionsPlist "$RUNNER_TEMP/exportOptions.plist" \
             -exportPath "$RUNNER_TEMP/app-store"
+
+      - name: Verify macOS App Store entitlements
+        if: ${{ steps.app-store-ready.outputs.ready == 'true' }}
+        run: |
+          APP_PATH="$(find "$RUNNER_TEMP/Runner.xcarchive/Products/Applications" -maxdepth 1 -name '*.app' -print -quit)"
+          codesign -d --entitlements :- "$APP_PATH" > "$RUNNER_TEMP/app-store-entitlements.plist"
+          grep -q 'applinks:app.sofarhangolo.hu' "$RUNNER_TEMP/app-store-entitlements.plist"
 
       - name: Upload App Store package artifact
         if: ${{ steps.app-store-ready.outputs.ready == 'true' }}

--- a/docs/desktop-release-setup.md
+++ b/docs/desktop-release-setup.md
@@ -210,6 +210,12 @@ Store that exact value in:
 
 - `MACOS_DEVELOPER_ID_APPLICATION`
 
+### 4a. Keep direct-distribution entitlements aligned
+
+The direct-distribution signing step uses `macos/Runner/DirectDistribution.entitlements`.
+
+If the universal-link host changes, update this file and verify the signed app contains the expected `Associated Domains` entitlement.
+
 ### 5. Create an App Store Connect API key for notarization
 
 In App Store Connect:
@@ -228,6 +234,12 @@ You will need:
 Reference:
 
 - <https://developer.apple.com/help/app-store-connect/get-started/app-store-connect-api>
+
+### 5a. Refresh App Store capabilities if universal-link domains change
+
+The App Store signing path uses `macos/Runner/Release.entitlements`.
+
+If a domain change introduces archive or export signing failures, refresh the app identifier capability and regenerate the provisioning profile before retrying the release workflow.
 
 ### 6. Encode the binary files for GitHub secrets
 

--- a/docs/desktop-release.md
+++ b/docs/desktop-release.md
@@ -41,6 +41,11 @@ Repository secrets:
 - `WINDOWS_STORE_CLIENT_ID`
 - `WINDOWS_STORE_CLIENT_SECRET`
 
+Notes:
+
+- Apps for Websites support is only expected for the MSIX / Microsoft Store package
+- the standalone `.exe` installer uses `lyric:` protocol registration as fallback
+
 ### macOS direct distribution
 
 Repository secrets:
@@ -51,6 +56,11 @@ Repository secrets:
 - `MACOS_NOTARY_API_KEY_ID`
 - `MACOS_NOTARY_API_ISSUER_ID`
 - `MACOS_NOTARY_API_KEY_BASE64`
+
+Notes:
+
+- direct distribution now signs with `macos/Runner/DirectDistribution.entitlements`
+- verify the signed `.app` contains `applinks:app.sofarhangolo.hu`
 
 ### macOS App Store beta
 
@@ -85,3 +95,4 @@ Repository secrets:
 - Windows beta publishing uses Microsoft Store flights via the Microsoft Store Developer CLI.
 - macOS beta publishing uploads the exported App Store package to App Store Connect. Processing and tester distribution remain controlled in App Store Connect.
 - Mobile release assets are built in Codemagic and attached by GitHub Actions after the matching tagged mobile build finishes.
+- Linux packaging supports the `lyric:` custom scheme, not verified HTTPS web-to-app linking.

--- a/linux/packaging/org.lyricapp.sofar.desktop
+++ b/linux/packaging/org.lyricapp.sofar.desktop
@@ -11,3 +11,4 @@ Categories=AudioVideo;Music;
 Keywords=lyrics;songbook;music;chords;
 StartupNotify=true
 StartupWMClass=sofarhangolo
+MimeType=x-scheme-handler/lyric;

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -10,5 +10,9 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:app.sofarhangolo.hu</string>
+	</array>
 </dict>
 </plist>

--- a/macos/Runner/DirectDistribution.entitlements
+++ b/macos/Runner/DirectDistribution.entitlements
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
-	<key>com.apple.security.network.client</key>
-	<true/>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:app.sofarhangolo.hu</string>

--- a/packaging/windows/sofar-hangolo.iss
+++ b/packaging/windows/sofar-hangolo.iss
@@ -39,5 +39,11 @@ Source: "..\..\build\windows\x64\runner\Release\*"; DestDir: "{app}"; Flags: ign
 Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
 Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
 
+[Registry]
+Root: HKCR; Subkey: "lyric"; ValueType: string; ValueData: "URL:lyric Protocol"; Flags: uninsdeletekey
+Root: HKCR; Subkey: "lyric"; ValueType: string; ValueName: "URL Protocol"; ValueData: ""
+Root: HKCR; Subkey: "lyric\DefaultIcon"; ValueType: string; ValueData: "{app}\{#MyAppExeName},0"
+Root: HKCR; Subkey: "lyric\shell\open\command"; ValueType: string; ValueData: """{app}\{#MyAppExeName}"" ""%1"""
+
 [Run]
 Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#StringChange(MyAppName, '&', '&&')}}"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
## Summary
- add macOS associated-domain entitlements for Debug/Profile/App Store signing and a dedicated direct-distribution entitlements file
- sign direct-distribution macOS builds with explicit entitlements and verify both macOS signing paths in CI
- register the `lyric:` protocol for the Windows installer and the Linux desktop file
- document the desktop deep-linking behavior and signing requirements

## Validation
- `flutter test test/services/app_link_navigation_test.dart`
- extracted the shipping Windows Store `.msix` to derive the real package family name used in the hosted `windows-app-web-link` file
- validated the `windows-app-web-link` JSON payload locally